### PR TITLE
Add a white background to pgplot TikZ output.

### DIFF
--- a/htdocs/js/Plots/plots.scss
+++ b/htdocs/js/Plots/plots.scss
@@ -2,5 +2,4 @@
 	display: inline-block;
 	margin: 1rem;
 	border-radius: 0px;
-	-webkit-border-radius: 0px;
 }

--- a/lib/Plots/Data.pm
+++ b/lib/Plots/Data.pm
@@ -163,7 +163,7 @@ sub size {
 
 sub x {
 	my ($self, $n) = @_;
-	return $self->{x}->[$n] if (defined($n) && defined($self->{x}->[$n]));
+	return $self->{x}[$n] if (defined($n) && defined($self->{x}[$n]));
 	return wantarray ? @{ $self->{x} } : $self->{x};
 }
 

--- a/lib/Plots/Tikz.pm
+++ b/lib/Plots/Tikz.pm
@@ -15,13 +15,14 @@ use warnings;
 sub new {
 	my ($class, $plots) = @_;
 	my $image = LaTeXImage->new;
-	$image->environment('tikzpicture');
+	$image->environment([ 'tikzpicture', 'framed' ]);
 	$image->svgMethod(eval('$main::envir{latexImageSVGMethod}')           // 'dvisvgm');
 	$image->convertOptions(eval('$main::envir{latexImageConvertOptions}') // { input => {}, output => {} });
 	$image->ext($plots->ext);
-	$image->tikzLibraries('arrows.meta,plotmarks');
+	$image->tikzLibraries('arrows.meta,plotmarks,backgrounds');
 	$image->texPackages(['pgfplots']);
-	$image->addToPreamble('\pgfplotsset{compat=1.18}\usepgfplotslibrary{fillbetween}');
+	$image->addToPreamble('\pgfplotsset{compat=1.18}\usepgfplotslibrary{fillbetween}'
+			. '\tikzset{inner frame sep=0pt,background rectangle/.style={thick,draw=DarkBlue,fill=white}}');
 
 	return bless { image => $image, plots => $plots, colors => {} }, $class;
 }


### PR DESCRIPTION
Also, don't add prefixed css (like `-webkit-border-radius`). Autoprefixer adds any of those that are needed. Note that this one is not added because it actually isn't needed anymore (unless we really want to support really old browsers).