### PR TITLE
Add imageview features to JSXGraph output of plots when the jsx_navigation option is false.

### DIFF
--- a/htdocs/js/ImageView/imageview.js
+++ b/htdocs/js/ImageView/imageview.js
@@ -112,7 +112,15 @@
 
 		const body = document.createElement('div');
 		body.classList.add('modal-body');
-		body.innerHTML = imgHtml;
+
+		let graphDiv = null;
+		if (imgType == 'div') {
+			graphDiv = document.createElement('div');
+			graphDiv.id = `magnified-${this.id}`;
+			body.append(graphDiv);
+		} else {
+			body.innerHTML = imgHtml;
+		}
 
 		zoomInButton.append(zoomInSVG);
 		zoomOutButton.append(zoomOutSVG);
@@ -135,6 +143,9 @@
 				// This assumes the units of the view box dimensions are points.
 				naturalWidth = (viewBoxDims.width * 4) / 3;
 				naturalHeight = (viewBoxDims.height * 4) / 3;
+			} else if (imgType == 'div') {
+				naturalWidth = this.clientWidth * 1.2;
+				naturalHeight = this.clientHeight * 1.2;
 			}
 
 			const headerHeight = header.offsetHeight;
@@ -150,6 +161,8 @@
 			// Initial image width and height
 			let width = naturalWidth;
 			let height = naturalHeight;
+
+			if (imgType == 'div') this.dispatchEvent(new Event('shown.imageview'));
 
 			// Dialog position
 			let left;
@@ -198,6 +211,12 @@
 				body.style.height = height + 'px';
 				dialog.style.width = width + 18 + 'px';
 				dialog.style.height = height + headerHeight + 18 + 'px';
+
+				if (graphDiv) {
+					graphDiv.style.width = width + 'px';
+					graphDiv.style.height = height + 'px';
+					this.dispatchEvent(new Event('resized.imageview'));
+				}
 
 				// Re-position the modal.
 				if (initial) {
@@ -289,6 +308,7 @@
 			backdrop.style.opacity = '0.2';
 		});
 		modal.addEventListener('hidden.bs.modal', () => {
+			if (imgType == 'div') this.dispatchEvent(new Event('hidden.imageview'));
 			bsModal.dispose();
 			modal.remove();
 			window.removeEventListener('resize', onWinResize);

--- a/htdocs/js/Plots/plots.scss
+++ b/htdocs/js/Plots/plots.scss
@@ -1,5 +1,4 @@
 .plots-jsxgraph {
 	display: inline-block;
-	margin: 1rem;
 	border-radius: 0px;
 }

--- a/lib/Plots/Axes.pm
+++ b/lib/Plots/Axes.pm
@@ -181,8 +181,10 @@ be visible after the fill, otherwise the fill will cover the axis. Default: 0
 
 =item jsx_navigation
 
-Either allow (1) or don't allow (0) the user to pan and zoom the view port of the JSXGraph.
-Best used when plotting functions with the C<continue> style. Default: 0
+Either allow (1) or don't allow (0) the user to pan and zoom the view port of the
+JSXGraph.  Best used when plotting functions with the C<continue> style. Note that if this
+option is 0, then the image can be clicked on to open a dialog showing a magnified version
+of the graph that can be zoomed in or out.  Default: 0
 
 =item jsx_options
 

--- a/lib/Plots/Data.pm
+++ b/lib/Plots/Data.pm
@@ -176,17 +176,16 @@ sub y {
 sub style {
 	my ($self, @styles) = @_;
 	return $self->{styles} unless @styles;
-	if (scalar(@styles) > 1) {
+	if (ref($styles[0]) eq 'HASH') {
+		map { $self->{styles}{$_} = $styles[0]{$_} } keys %{ $styles[0] };
+		return;
+	}
+	if (@styles % 2 == 0) {
 		my %style_hash = @styles;
-		map { $self->{styles}{$_} = $style_hash{$_}; } (keys %style_hash);
+		map { $self->{styles}{$_} = $style_hash{$_} } keys %style_hash;
 		return;
 	}
-	my $style = $styles[0];
-	if (ref($style) eq 'HASH') {
-		map { $self->{styles}{$_} = $style->{$_}; } (keys %$style);
-		return;
-	}
-	return $self->{styles}{$style};
+	return $self->{styles}{ $styles[0] };
 }
 
 sub get_math_object {

--- a/lib/Plots/JSXGraph.pm
+++ b/lib/Plots/JSXGraph.pm
@@ -32,19 +32,19 @@ sub HTML {
 	my $name = $self->{name};
 	my ($width, $height) = $self->plots->size;
 
-	return <<END_HTML;
-<div id="board_$name" class="jxgbox plots-jsxgraph" style="width: ${width}px; height: ${height}px;"></div>
-<script>
-(() => {
-	const draw_board_$name = () => {
-$self->{JS}
-$self->{JSend}
-	}
-	if (document.readyState === 'loading') window.addEventListener('DOMContentLoaded', draw_board_$name);
-	else draw_board_$name();
-})();
-</script>
-END_HTML
+	return <<~ "END_HTML";
+		<div id="board_$name" class="jxgbox plots-jsxgraph" style="width: ${width}px; height: ${height}px;"></div>
+		<script>
+		(() => {
+			const draw_board_$name = () => {
+				$self->{JS}
+				$self->{JSend}
+			}
+			if (document.readyState === 'loading') window.addEventListener('DOMContentLoaded', draw_board_$name);
+			else draw_board_$name();
+		})();
+		</script>
+		END_HTML
 }
 
 sub get_color {
@@ -120,7 +120,6 @@ sub add_curve {
 		$data_points = '[[' . join(',', $data->x) . '],[' . join(',', $data->y) . ']]';
 	}
 
-	$self->{JS} .= "\n\t\t";
 	if ($curve_name) {
 		$self->{JS} .= "const curve_${curve_name}_$name = ";
 	}
@@ -140,50 +139,45 @@ sub add_curve {
 
 		if ($fill eq 'xaxis') {
 			$self->{JSend} .=
-				"\n\t\tconst fill_${curve_name}_$name = board_$name.create('curve', [[], []], $fillOptions);\n"
-				. "\t\tfill_${curve_name}_$name.updateDataArray = function () {\n"
-				. "\t\t\tconst points = curve_${curve_name}_$name.points";
+				"const fill_${curve_name}_$name = board_$name.create('curve', [[], []], $fillOptions);"
+				. "fill_${curve_name}_$name.updateDataArray = function () {"
+				. "const points = curve_${curve_name}_$name.points";
 			if (defined $fill_min && defined $fill_max) {
 				$self->{JSend} .=
-					".filter(p => {\n"
-					. "\t\t\t\treturn p.usrCoords[1] >= $fill_min && p.usrCoords[1] <= $fill_max ? true : false\n"
-					. "\t\t\t})";
+					".filter(p => {"
+					. "return p.usrCoords[1] >= $fill_min && p.usrCoords[1] <= $fill_max ? true : false" . "})";
 			}
 			$self->{JSend} .=
-				";\n\t\t\tthis.dataX = points.map( p => p.usrCoords[1] );\n"
-				. "\t\t\tthis.dataY = points.map( p => p.usrCoords[2] );\n"
-				. "\t\t\tthis.dataX.push(points[points.length - 1].usrCoords[1], "
-				. "points[0].usrCoords[1], points[0].usrCoords[1]);\n"
-				. "\t\t\tthis.dataY.push(0, 0, points[0].usrCoords[2]);\n"
-				. "\t\t};\n"
-				. "\t\tboard_$name.update();";
+				";this.dataX = points.map( p => p.usrCoords[1] );"
+				. "this.dataY = points.map( p => p.usrCoords[2] );"
+				. "this.dataX.push(points[points.length - 1].usrCoords[1], "
+				. "points[0].usrCoords[1], points[0].usrCoords[1]);"
+				. "this.dataY.push(0, 0, points[0].usrCoords[2]);" . "};"
+				. "board_$name.update();";
 		} else {
 			$self->{JSend} .=
-				"\n\t\tconst fill_${curve_name}_$name = board_$name.create('curve', [[], []], $fillOptions);\n"
-				. "\t\tfill_${curve_name}_$name.updateDataArray = function () {\n"
-				. "\t\t\tconst points1 = curve_${curve_name}_$name.points";
+				"const fill_${curve_name}_$name = board_$name.create('curve', [[], []], $fillOptions);"
+				. "fill_${curve_name}_$name.updateDataArray = function () {"
+				. "const points1 = curve_${curve_name}_$name.points";
 			if (defined $fill_min && defined $fill_max) {
 				$self->{JSend} .=
-					".filter(p => {\n"
-					. "\t\t\t\treturn p.usrCoords[1] >= $fill_min && p.usrCoords[1] <= $fill_max ? true : false\n"
-					. "\t\t\t})";
+					".filter(p => {"
+					. "return p.usrCoords[1] >= $fill_min && p.usrCoords[1] <= $fill_max ? true : false" . "})";
 			}
-			$self->{JSend} .= ";\n\t\t\tconst points2 = curve_${fill}_$name.points";
+			$self->{JSend} .= ";const points2 = curve_${fill}_$name.points";
 			if (defined $fill_min && defined $fill_max) {
 				$self->{JSend} .=
-					".filter(p => {\n"
-					. "\t\t\t\treturn p.usrCoords[1] >= $fill_min && p.usrCoords[1] <= $fill_max ? true : false\n"
-					. "\t\t\t})";
+					".filter(p => {"
+					. "return p.usrCoords[1] >= $fill_min && p.usrCoords[1] <= $fill_max ? true : false" . "})";
 			}
 			$self->{JSend} .=
-				";\n\t\t\tthis.dataX = points1.map( p => p.usrCoords[1] ).concat("
-				. "points2.map( p => p.usrCoords[1] ).reverse());\n"
-				. "\t\t\tthis.dataY = points1.map( p => p.usrCoords[2] ).concat("
-				. "points2.map( p => p.usrCoords[2] ).reverse());\n"
-				. "\t\t\tthis.dataX.push(points1[0].usrCoords[1]);\n"
-				. "\t\t\tthis.dataY.push(points1[0].usrCoords[2]);\n"
-				. "\t\t};\n"
-				. "\t\tboard_$name.update();";
+				";this.dataX = points1.map( p => p.usrCoords[1] ).concat("
+				. "points2.map( p => p.usrCoords[1] ).reverse());"
+				. "this.dataY = points1.map( p => p.usrCoords[2] ).concat("
+				. "points2.map( p => p.usrCoords[2] ).reverse());"
+				. "this.dataX.push(points1[0].usrCoords[1]);"
+				. "this.dataY.push(points1[0].usrCoords[2]);" . "};"
+				. "board_$name.update();";
 		}
 	}
 }
@@ -238,7 +232,7 @@ sub add_point {
 	$pointOptions = "JXG.merge($pointOptions, " . Mojo::JSON::encode_json($data->style('jsx_options')) . ')'
 		if $data->style('jsx_options');
 
-	$self->{JS} .= "\n\t\tboard_$name.create('point', [$x, $y], $pointOptions);";
+	$self->{JS} .= "board_$name.create('point', [$x, $y], $pointOptions);";
 }
 
 sub add_points {
@@ -365,11 +359,11 @@ sub init_graph {
 		if $axes->yaxis('jsx_options');
 
 	$self->{JSend} = '';
-	$self->{JS}    = <<END_JS;
-		const board_$name = JXG.JSXGraph.initBoard('board_$name', $JSXOptions);
-		board_$name.create('axis', [[0, $xaxis_pos], [1, $xaxis_pos]], $XAxisOptions);
-		board_$name.create('axis', [[$yaxis_pos, 0], [$yaxis_pos, 1]], $YAxisOptions);
-END_JS
+	$self->{JS}    = <<~ "END_JS";
+			const board_$name = JXG.JSXGraph.initBoard('board_$name', $JSXOptions);
+			board_$name.create('axis', [[0, $xaxis_pos], [1, $xaxis_pos]], $XAxisOptions);
+			board_$name.create('axis', [[$yaxis_pos, 0], [$yaxis_pos, 1]], $YAxisOptions);
+		END_JS
 }
 
 sub draw {
@@ -410,7 +404,7 @@ sub draw {
 				$xfunction = $xtmp;
 			}
 
-			$self->{JS} .= "\n\t\tboard_$name.create('vectorfield', [[(x,y) => $xfunction, (x,y) => $yfunction], "
+			$self->{JS} .= "board_$name.create('vectorfield', [[(x,y) => $xfunction, (x,y) => $yfunction], "
 				. "[$f->{xmin}, $f->{xsteps}, $f->{xmax}], [$f->{ymin}, $f->{ysteps}, $f->{ymax}]], $options);";
 		} else {
 			warn "Vector field not created due to missing JavaScript functions.";
@@ -453,7 +447,7 @@ sub draw {
 		$textOptions = "JXG.merge($textOptions, " . Mojo::JSON::encode_json($label->style('jsx_options')) . ')'
 			if $label->style('jsx_options');
 
-		$self->{JS} .= "\n\t\tboard_$name.create('text', [$x, $y, '$str'], $textOptions);";
+		$self->{JS} .= "board_$name.create('text', [$x, $y, '$str'], $textOptions);";
 	}
 
 	# JSXGraph only produces HTML graphs and uses TikZ for hadrcopy.

--- a/lib/Plots/JSXGraph.pm
+++ b/lib/Plots/JSXGraph.pm
@@ -32,16 +32,37 @@ sub HTML {
 	my $name = $self->{name};
 	my ($width, $height) = $self->plots->size;
 
+	my $imageviewClass = $self->plots->axes->style('jsx_navigation') ? '' : ' image-view-elt';
+	my $tabindex       = $self->plots->axes->style('jsx_navigation') ? '' : ' tabindex="0"';
+
 	return <<~ "END_HTML";
-		<div id="board_$name" class="jxgbox plots-jsxgraph" style="width: ${width}px; height: ${height}px;"></div>
+		<div id="jsxgraph-plot-$name" class="jxgbox plots-jsxgraph$imageviewClass"$tabindex
+			style="width: ${width}px; height: ${height}px;"></div>
 		<script>
 		(() => {
-			const draw_board_$name = () => {
+			const drawBoard = (id) => {
 				$self->{JS}
 				$self->{JSend}
+				return board;
 			}
-			if (document.readyState === 'loading') window.addEventListener('DOMContentLoaded', draw_board_$name);
-			else draw_board_$name();
+			if (document.readyState === 'loading')
+				window.addEventListener('DOMContentLoaded', () => drawBoard('jsxgraph-plot-$name'));
+			else drawBoard('jsxgraph-plot-$name');
+
+			const jsxPlotDiv = document.getElementById('jsxgraph-plot-$name');
+
+			let jsxBoard = null;
+			jsxPlotDiv?.addEventListener('shown.imageview', () => {
+				document.getElementById('magnified-jsxgraph-plot-$name')?.classList.add('jxgbox', 'plots-jsxgraph');
+				jsxBoard = drawBoard('magnified-jsxgraph-plot-$name');
+			});
+			jsxPlotDiv?.addEventListener('resized.imageview', () => {
+				jsxBoard?.resizeContainer(jsxBoard.containerObj.clientWidth, jsxBoard.containerObj.clientHeight, true);
+			});
+			jsxPlotDiv?.addEventListener('hidden.imageview', () => {
+				if (jsxBoard) JXG.JSXGraph.freeBoard(jsxBoard);
+				jsxBoard = null;
+			});
 		})();
 		</script>
 		END_HTML
@@ -73,7 +94,6 @@ sub add_curve {
 
 	my $start        = $data->style('start_mark') || '';
 	my $end          = $data->style('end_mark')   || '';
-	my $name         = $self->{name};
 	my $curve_name   = $data->style('name');
 	my $color        = $self->get_color($data->style('color') || 'default_color');
 	my $line_width   = $data->style('width') || 2;
@@ -121,9 +141,9 @@ sub add_curve {
 	}
 
 	if ($curve_name) {
-		$self->{JS} .= "const curve_${curve_name}_$name = ";
+		$self->{JS} .= "const curve_${curve_name} = ";
 	}
-	$self->{JS} .= "board_$name.create('$type', $data_points, $plotOptions);";
+	$self->{JS} .= "board.create('$type', $data_points, $plotOptions);";
 	$self->add_point($data, $data->get_start_point, $line_width, $start, $color) if $start =~ /circle/;
 	$self->add_point($data, $data->get_end_point,   $line_width, $end,   $color) if $end   =~ /circle/;
 	if ($curve_name && $fill ne 'none' && $fill ne 'self') {
@@ -139,9 +159,9 @@ sub add_curve {
 
 		if ($fill eq 'xaxis') {
 			$self->{JSend} .=
-				"const fill_${curve_name}_$name = board_$name.create('curve', [[], []], $fillOptions);"
-				. "fill_${curve_name}_$name.updateDataArray = function () {"
-				. "const points = curve_${curve_name}_$name.points";
+				"const fill_${curve_name} = board.create('curve', [[], []], $fillOptions);"
+				. "fill_${curve_name}.updateDataArray = function () {"
+				. "const points = curve_${curve_name}.points";
 			if (defined $fill_min && defined $fill_max) {
 				$self->{JSend} .=
 					".filter(p => {"
@@ -153,18 +173,18 @@ sub add_curve {
 				. "this.dataX.push(points[points.length - 1].usrCoords[1], "
 				. "points[0].usrCoords[1], points[0].usrCoords[1]);"
 				. "this.dataY.push(0, 0, points[0].usrCoords[2]);" . "};"
-				. "board_$name.update();";
+				. "board.update();";
 		} else {
 			$self->{JSend} .=
-				"const fill_${curve_name}_$name = board_$name.create('curve', [[], []], $fillOptions);"
-				. "fill_${curve_name}_$name.updateDataArray = function () {"
-				. "const points1 = curve_${curve_name}_$name.points";
+				"const fill_${curve_name} = board.create('curve', [[], []], $fillOptions);"
+				. "fill_${curve_name}.updateDataArray = function () {"
+				. "const points1 = curve_${curve_name}.points";
 			if (defined $fill_min && defined $fill_max) {
 				$self->{JSend} .=
 					".filter(p => {"
 					. "return p.usrCoords[1] >= $fill_min && p.usrCoords[1] <= $fill_max ? true : false" . "})";
 			}
-			$self->{JSend} .= ";const points2 = curve_${fill}_$name.points";
+			$self->{JSend} .= ";const points2 = curve_${fill}.points";
 			if (defined $fill_min && defined $fill_max) {
 				$self->{JSend} .=
 					".filter(p => {"
@@ -177,7 +197,7 @@ sub add_curve {
 				. "points2.map( p => p.usrCoords[2] ).reverse());"
 				. "this.dataX.push(points1[0].usrCoords[1]);"
 				. "this.dataY.push(points1[0].usrCoords[2]);" . "};"
-				. "board_$name.update();";
+				. "board.update();";
 		}
 	}
 }
@@ -185,7 +205,6 @@ sub add_curve {
 sub add_point {
 	my ($self, $data, $x, $y, $size, $mark, $color) = @_;
 	my $fill = $color;
-	my $name = $self->{name};
 
 	if ($mark eq 'circle' || $mark eq 'closed_circle') {
 		$mark = 'o';
@@ -232,7 +251,7 @@ sub add_point {
 	$pointOptions = "JXG.merge($pointOptions, " . Mojo::JSON::encode_json($data->style('jsx_options')) . ')'
 		if $data->style('jsx_options');
 
-	$self->{JS} .= "board_$name.create('point', [$x, $y], $pointOptions);";
+	$self->{JS} .= "board.create('point', [$x, $y], $pointOptions);";
 }
 
 sub add_points {
@@ -252,7 +271,6 @@ sub init_graph {
 	my $self             = shift;
 	my $plots            = $self->plots;
 	my $axes             = $plots->axes;
-	my $name             = $self->{name};
 	my $xaxis_loc        = $axes->xaxis('location');
 	my $yaxis_loc        = $axes->yaxis('location');
 	my $xaxis_pos        = $axes->xaxis('position');
@@ -265,12 +283,12 @@ sub init_graph {
 
 	# Determine if zero should be drawn on the axis.
 	my $x_draw_zero =
-		$axes->style('jsx_navigation')
+		$allow_navigation
 		|| ($yaxis_loc eq 'center' && $yaxis_pos != 0)
 		|| ($yaxis_loc eq 'left'   && $ymin != 0)
 		|| ($yaxis_loc eq 'right'  && $ymax != 0) ? 1 : 0;
 	my $y_draw_zero =
-		$axes->style('jsx_navigation')
+		$allow_navigation
 		|| ($xaxis_loc eq 'middle' && $xaxis_pos != 0)
 		|| ($xaxis_loc eq 'bottom' && $xmin != 0)
 		|| ($xaxis_loc eq 'top'    && $xmax != 0) ? 1 : 0;
@@ -294,18 +312,23 @@ sub init_graph {
 	$JSXOptions = "JXG.merge($JSXOptions, " . Mojo::JSON::encode_json($axes->style('jsx_options')) . ')'
 		if $axes->style('jsx_options');
 	my $XAxisOptions = Mojo::JSON::encode_json({
-		name       => $axes->xaxis('label'),
-		withLabel  => 1,
-		position   => $xaxis_loc eq 'middle'  ? 'sticky' : 'fixed',
-		anchor     => $xaxis_loc eq 'top'     ? 'left'   : $xaxis_loc eq 'bottom' ? 'right' : 'right left',
-		visible    => $axes->xaxis('visible') ? 1        : 0,
-		highlight  => 0,
-		firstArrow => { size => 7 },
-		lastArrow  => { size => 7 },
-		label      => {
-			position  => 'lrt',
-			offset    => [ -4, 8 ],
-			highlight => 0
+		name          => $axes->xaxis('label'),
+		withLabel     => 1,
+		position      => $xaxis_loc eq 'middle'  ? 'sticky' : 'fixed',
+		anchor        => $xaxis_loc eq 'top'     ? 'left'   : $xaxis_loc eq 'bottom' ? 'right' : 'right left',
+		visible       => $axes->xaxis('visible') ? 1        : 0,
+		highlight     => 0,
+		firstArrow    => 0,
+		lastArrow     => { size => 7 },
+		straightFirst => 0,
+		straightLast  => 0,
+		label         => {
+			anchorX    => 'middle',
+			anchorY    => 'middle',
+			position   => '100% left',
+			offset     => [ -10, 0 ],
+			highlight  => 0,
+			useMathJax => 1
 		},
 		ticks => {
 			drawLabels    => $axes->xaxis('tick_labels') && $axes->xaxis('show_ticks') ? 1 : 0,
@@ -326,18 +349,23 @@ sub init_graph {
 	$XAxisOptions = "JXG.merge($XAxisOptions, " . Mojo::JSON::encode_json($axes->xaxis('jsx_options')) . ')'
 		if $axes->xaxis('jsx_options');
 	my $YAxisOptions = Mojo::JSON::encode_json({
-		name       => $axes->yaxis('label'),
-		withLabel  => 1,
-		position   => $yaxis_loc eq 'center'  ? 'sticky'     : 'fixed',
-		anchor     => $yaxis_loc eq 'center'  ? 'right left' : $yaxis_loc,
-		visible    => $axes->yaxis('visible') ? 1            : 0,
-		highlight  => 0,
-		firstArrow => { size => 7 },
-		lastArrow  => { size => 7 },
-		label      => {
-			position  => 'rt',
-			offset    => [ 6, 0 ],
-			highlight => 0,
+		name          => $axes->yaxis('label'),
+		withLabel     => 1,
+		position      => $yaxis_loc eq 'center'  ? 'sticky'     : 'fixed',
+		anchor        => $yaxis_loc eq 'center'  ? 'right left' : $yaxis_loc,
+		visible       => $axes->yaxis('visible') ? 1            : 0,
+		highlight     => 0,
+		firstArrow    => 0,
+		lastArrow     => { size => 7 },
+		straightFirst => 0,
+		straightLast  => 0,
+		label         => {
+			anchorX    => 'middle',
+			anchorY    => 'middle',
+			position   => '100% right',
+			offset     => [ 6, -10 ],
+			highlight  => 0,
+			useMathJax => 1
 		},
 		ticks => {
 			drawLabels    => $axes->yaxis('tick_labels') && $axes->yaxis('show_ticks') ? 1 : 0,
@@ -360,17 +388,16 @@ sub init_graph {
 
 	$self->{JSend} = '';
 	$self->{JS}    = <<~ "END_JS";
-			const board_$name = JXG.JSXGraph.initBoard('board_$name', $JSXOptions);
-			board_$name.create('axis', [[0, $xaxis_pos], [1, $xaxis_pos]], $XAxisOptions);
-			board_$name.create('axis', [[$yaxis_pos, 0], [$yaxis_pos, 1]], $YAxisOptions);
+			const board = JXG.JSXGraph.initBoard(id, $JSXOptions);
+			board.create('axis', [[$xmin, $xaxis_pos], [$xmax, $xaxis_pos]], $XAxisOptions);
+			board.create('axis', [[$yaxis_pos, $ymin], [$yaxis_pos, $ymax]], $YAxisOptions);
 		END_JS
 }
 
 sub draw {
 	my $self  = shift;
 	my $plots = $self->plots;
-	my $name  = $plots->get_image_name =~ s/-/_/gr;
-	$self->{name} = $name;
+	$self->{name} = $plots->get_image_name =~ s/-/_/gr;
 
 	$self->init_graph;
 
@@ -404,7 +431,7 @@ sub draw {
 				$xfunction = $xtmp;
 			}
 
-			$self->{JS} .= "board_$name.create('vectorfield', [[(x,y) => $xfunction, (x,y) => $yfunction], "
+			$self->{JS} .= "board.create('vectorfield', [[(x,y) => $xfunction, (x,y) => $yfunction], "
 				. "[$f->{xmin}, $f->{xsteps}, $f->{xmax}], [$f->{ymin}, $f->{ysteps}, $f->{ymax}]], $options);";
 		} else {
 			warn "Vector field not created due to missing JavaScript functions.";
@@ -447,7 +474,7 @@ sub draw {
 		$textOptions = "JXG.merge($textOptions, " . Mojo::JSON::encode_json($label->style('jsx_options')) . ')'
 			if $label->style('jsx_options');
 
-		$self->{JS} .= "board_$name.create('text', [$x, $y, '$str'], $textOptions);";
+		$self->{JS} .= "board.create('text', [$x, $y, '$str'], $textOptions);";
 	}
 
 	# JSXGraph only produces HTML graphs and uses TikZ for hadrcopy.

--- a/lib/Plots/JSXGraph.pm
+++ b/lib/Plots/JSXGraph.pm
@@ -47,6 +47,9 @@ sub HTML {
 				$self->{JS}
 				$self->{JSend}
 				board.unsuspendUpdate();
+				// This is a workaround for an issue when the magnified graph is drawn in the imageview dialog.
+				// In that case something is messing up the bounding box, so it needs to be reset.
+				board.setBoundingBox(board.attr.boundingbox, board.keepaspectratio, 'keep');
 				return board;
 			}
 

--- a/lib/Plots/Tikz.pm
+++ b/lib/Plots/Tikz.pm
@@ -124,8 +124,8 @@ sub configure_axes {
 	my $yminor       = $show_grid && $yminor_num > 0 ? 'true'                                : 'false';
 	my $xticks       = $axes->xaxis('show_ticks')    ? "xtick distance=$grid->{xtick_delta}" : 'xticks=none';
 	my $yticks       = $axes->yaxis('show_ticks')    ? "ytick distance=$grid->{ytick_delta}" : 'yticks=none';
-	my $xtick_labels = $axes->xaxis('tick_labels')   ? '' : "\n\t\t\txticklabel=\\empty,";
-	my $ytick_labels = $axes->yaxis('tick_labels')   ? '' : "\n\t\t\tyticklabel=\\empty,";
+	my $xtick_labels = $axes->xaxis('tick_labels')   ? ''                                    : "\nxticklabel=\\empty,";
+	my $ytick_labels = $axes->yaxis('tick_labels')   ? ''                                    : "\nyticklabel=\\empty,";
 	my $grid_color   = $axes->style('grid_color');
 	my $grid_color2  = $self->get_color($grid_color);
 	my $grid_alpha   = $axes->style('grid_alpha');
@@ -136,28 +136,22 @@ sub configure_axes {
 	my $ylabel       = $axes->yaxis('label');
 	my $axis_y_line  = $axes->yaxis('location');
 	my $axis_y_pos   = $axes->yaxis('position');
-	my $axis_on_top  = $axes->style('axis_on_top') ? "axis on top,\n\t\t\t" : '';
+	my $axis_on_top  = $axes->style('axis_on_top') ? "axis on top,\n" : '';
 	my $hide_x_axis  = '';
 	my $hide_y_axis  = '';
 	my $xaxis_plot   = ($xmin <= 0 && $xmax >= 0) ? "\\path[name path=xaxis] ($xmin, 0) -- ($xmax,0);\n" : '';
-	$axis_x_pos = $axis_x_pos ? ",\n\t\t\taxis x line shift=" . (-$axis_x_pos) : '';
-	$axis_y_pos = $axis_y_pos ? ",\n\t\t\taxis y line shift=" . (-$axis_y_pos) : '';
+	$axis_x_pos = $axis_x_pos ? ",\naxis x line shift=" . (-$axis_x_pos) : '';
+	$axis_y_pos = $axis_y_pos ? ",\naxis y line shift=" . (-$axis_y_pos) : '';
 
 	unless ($axes->xaxis('visible')) {
-		$xlabel = '';
-		$hide_x_axis =
-			"\n\t\t\tx axis line style={draw=none},\n"
-			. "\t\t\tx tick style={draw=none},\n"
-			. "\t\t\txticklabel=\\empty,";
+		$xlabel      = '';
+		$hide_x_axis = "\nx axis line style={draw=none},\n" . "x tick style={draw=none},\n" . "xticklabel=\\empty,";
 	}
 	unless ($axes->yaxis('visible')) {
-		$ylabel = '';
-		$hide_y_axis =
-			"\n\t\t\ty axis line style={draw=none},\n"
-			. "\t\t\ty tick style={draw=none},\n"
-			. "\t\t\tyticklabel=\\empty,";
+		$ylabel      = '';
+		$hide_y_axis = "\ny axis line style={draw=none},\n" . "y tick style={draw=none},\n" . "yticklabel=\\empty,";
 	}
-	my $tikzCode = <<END_TIKZ;
+	my $tikzCode = <<~ "END_TIKZ";
 		\\begin{axis}
 		[
 			trig format plots=rad,
@@ -183,12 +177,10 @@ sub configure_axes {
 			ymax=$ymax,$hide_x_axis$hide_y_axis
 		]
 		$grid_color2$xaxis_plot
-END_TIKZ
+		END_TIKZ
 	chop($tikzCode);
-	$tikzCode =~ s/^\t\t//;
-	$tikzCode =~ s/\n\t\t/\n/g;
 
-	return $tikzCode;
+	return $tikzCode =~ s/^\t//gr;
 }
 
 sub get_plot_opts {


### PR DESCRIPTION
There are also some changes for consistency between JSXGraqh and TikZ output.  The axes arrows now only point in the positive direction, and extend to the edge of the board. With the the axes label positioning needed to be changed.  Furthermore, the JSXGraph preferred method for setting the `position` option of a label is switched to (see https://jsxgraph.org/docs/symbols/Label.html#position).
    
Also remove the `$name` suffixes to variables in the javascript.  This javascript is scoped and that suffix is unnecessary. The variable names to not need to be distinct between different JSXGraph images with the scoping.  Furthmore, it increases the size of the generated javascript which is not desirable.

Remove the injection of `\t` in the JSXGraph and TikZ output.  Do not attempt to make the output human readable.  That is not a desired goal.  In fact for the JavasScript output the goal should be to make the output as unreadable as possible.  That code is visible to the student, and could be used in some cases to assist in finding the answer.  For the TikZ code, the objective should be to make the result compile with as few characters as possible.  TeX has limits on the number of characters it can handle in a given line and we don't want to press that limit. The important thing is TeX is that newlines (`\n`) are where they need to be.
    
Remove the margin on the JSXGraph div.  That is inconsistent with the other display output modes.