### PR TITLE
A better fix for the JSXGraph imageview issue.

### DIFF
--- a/htdocs/js/ImageView/imageview.js
+++ b/htdocs/js/ImageView/imageview.js
@@ -162,7 +162,11 @@
 			let width = naturalWidth;
 			let height = naturalHeight;
 
-			if (imgType == 'div') this.dispatchEvent(new Event('shown.imageview'));
+			if (graphDiv) {
+				graphDiv.style.width = `${naturalWidth}px`;
+				graphDiv.style.height = `${naturalHeight}px`;
+				this.dispatchEvent(new Event('shown.imageview'));
+			}
 
 			// Dialog position
 			let left;

--- a/lib/Plots/JSXGraph.pm
+++ b/lib/Plots/JSXGraph.pm
@@ -40,21 +40,16 @@ sub HTML {
 			style="width: ${width}px; height: ${height}px;"></div>
 		<script>
 		(async () => {
-			const jsxPlotDiv = document.getElementById('jsxgraph-plot-$name');
-			if (!jsxPlotDiv) return;
-
 			const drawBoard = (id) => {
 				$self->{JS}
 				$self->{JSend}
 				board.unsuspendUpdate();
-				// This is a workaround for an issue when the magnified graph is drawn in the imageview dialog.
-				// In that case something is messing up the bounding box, so it needs to be reset.
-				board.setBoundingBox(board.attr.boundingbox, board.keepaspectratio, 'keep');
 				return board;
 			}
 
 			const drawPromise = (id) => new Promise((resolve) => {
-				if (jsxPlotDiv.offsetWidth === 0) {
+				const container = document.getElementById(id);
+				if (!container || container.offsetWidth === 0) {
 					setTimeout(async () => resolve(await drawPromise(id)), 100);
 					return;
 				}
@@ -66,6 +61,8 @@ sub HTML {
 					await drawPromise('jsxgraph-plot-$name')
 				});
 			else await drawPromise('jsxgraph-plot-$name');
+
+			const jsxPlotDiv = document.getElementById('jsxgraph-plot-$name');
 
 			let jsxBoard = null;
 			jsxPlotDiv?.addEventListener('shown.imageview', async () => {


### PR DESCRIPTION
There were two connected problems.  First, I was not checking the correct container div size in the "drawPromise" for the dialog version of the graph. I was always checking the div for the main JSXGraph image in the page.  Although, that doesn't entirely matter since the real problem was that the imageview JSXGraph div did not have its size set on initialization (which I do in all of the other places where I do this sort of thing with JSXGraph).